### PR TITLE
correcting handler config example

### DIFF
--- a/lita_config_sample.rb
+++ b/lita_config_sample.rb
@@ -1,4 +1,4 @@
 Lita.configure do |config|
   config.handlers.forecast_io.api_key = 'yourforecastiokey'
-  config.handlers.forecast_io.api_url = 'https://api.forecast.io/forecast/'
+  config.handlers.forecast_io.api_uri = 'https://api.forecast.io/forecast/'
 end


### PR DESCRIPTION
`bundle exec lita` throws error when attempting to use `api_url` as forecast_io config.handler key  - grep'd through and changed to `api_uri` based on test syntax and all seems well.
